### PR TITLE
Fix deprecation warning; Tiny cleanups

### DIFF
--- a/akkeeper/src/main/scala/akkeeper/master/service/ContainerService.scala
+++ b/akkeeper/src/main/scala/akkeeper/master/service/ContainerService.scala
@@ -26,7 +26,7 @@ private[akkeeper] class ContainerService extends Actor with ActorLogging {
   private val containers: mutable.Map[String, ContainerDefinition] = mutable.Map.empty
 
   override def preStart(): Unit = {
-    loadContainersFromConfig
+    loadContainersFromConfig()
     log.info("Container service successfully initialized")
     super.preStart()
   }

--- a/akkeeper/src/main/scala/akkeeper/utils/ConfigUtils.scala
+++ b/akkeeper/src/main/scala/akkeeper/utils/ConfigUtils.scala
@@ -90,7 +90,7 @@ private[akkeeper] object ConfigUtils {
     def getContainers: Seq[ContainerDefinition] = {
       if (config.hasPath("akkeeper.containers")) {
         val configContainers = config.getConfigList("akkeeper.containers").asScala
-        configContainers.map(ContainerDefinition.fromConfig(_))
+        configContainers.map(ContainerDefinition.fromConfig)
       } else {
         Seq.empty
       }

--- a/akkeeper/src/main/scala/akkeeper/utils/yarn/YarnLocalResourceManager.scala
+++ b/akkeeper/src/main/scala/akkeeper/utils/yarn/YarnLocalResourceManager.scala
@@ -15,13 +15,12 @@
  */
 package akkeeper.utils.yarn
 
-import java.io.{Closeable, FileInputStream, InputStream}
+import java.io.{Closeable, InputStream}
 
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.apache.hadoop.yarn.api.records._
-import org.apache.hadoop.yarn.util.ConverterUtils
 
 private[akkeeper] final class YarnLocalResourceManager(conf: Configuration,
                                                        stagingDir: String) {
@@ -39,7 +38,7 @@ private[akkeeper] final class YarnLocalResourceManager(conf: Configuration,
 
   private def create(fs: FileSystem, status: FileStatus): LocalResource = {
     LocalResource.newInstance(
-      ConverterUtils.getYarnUrlFromURI(fs.makeQualified(status.getPath).toUri()),
+      URL.fromURI(fs.makeQualified(status.getPath).toUri),
       LocalResourceType.FILE, LocalResourceVisibility.APPLICATION,
       status.getLen, status.getModificationTime
     )


### PR DESCRIPTION
1. Fix deprecation waring in YarnLocalResourceManager.scala
2. Tiny cleanups in some other files.